### PR TITLE
use scala-uri to encode Google Sheets API paths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ lazy val attoVersion = "0.7.2"
 lazy val hammockVersion = "0.10.0"
 lazy val scalacheckVersion = "1.14.3"
 lazy val scalatestVersion = "3.1.0"
+lazy val scalaUriVersion = "2.0.0"
 
 lazy val gsheets4s = project.in(file("."))
   .settings(name := "gsheets4s")
@@ -54,7 +55,8 @@ lazy val gsheets4s = project.in(file("."))
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % catsVersion,
       "org.typelevel" %% "cats-effect" % catsEffectVersion,
-      "eu.timepit" %% "refined" % refinedVersion
+      "eu.timepit" %% "refined" % refinedVersion,
+      "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
     ) ++ Seq(
       "io.circe" %% "circe-core",
       "io.circe" %% "circe-generic",

--- a/src/main/scala/gsheets4s/interpreters/RestSpreadsheetsValues.scala
+++ b/src/main/scala/gsheets4s/interpreters/RestSpreadsheetsValues.scala
@@ -1,8 +1,8 @@
 package gsheets4s
 package interpreters
 
-import cats.syntax.show._
 import io.circe.generic.auto._
+import io.lemonlabs.uri.typesafe.dsl._
 
 import algebras.SpreadsheetsValues
 import http._
@@ -10,7 +10,7 @@ import model._
 
 class RestSpreadsheetsValues[F[_]](client: HttpClient[F]) extends SpreadsheetsValues[F] {
   def get(spreadsheetID: String, range: A1Notation): F[Either[GsheetsError, ValueRange]] =
-    client.get(s"$spreadsheetID/values/${range.show}")
+    client.get(spreadsheetID / "values" / range)
 
   def update(
     spreadsheetID: String,
@@ -18,6 +18,6 @@ class RestSpreadsheetsValues[F[_]](client: HttpClient[F]) extends SpreadsheetsVa
     updates: ValueRange,
     valueInputOption: ValueInputOption
   ): F[Either[GsheetsError, UpdateValuesResponse]] =
-    client.put(s"$spreadsheetID/values/${range.show}", updates,
+    client.put(spreadsheetID / "values" / range, updates,
       List(("valueInputOption", valueInputOption.value)))
 }

--- a/src/main/scala/gsheets4s/model.scala
+++ b/src/main/scala/gsheets4s/model.scala
@@ -15,6 +15,7 @@ import eu.timepit.refined.numeric._
 import gsheets4s.model.A1Notation
 import io.circe.{Decoder, DecodingFailure, Encoder, HCursor}
 import io.circe.generic.semiauto._
+import io.lemonlabs.uri.typesafe._
 
 object model extends A1NotationLiteralSyntax {
   type ValidCol = NonEmpty And Forall[UpperCase]
@@ -50,6 +51,7 @@ object model extends A1NotationLiteralSyntax {
 
   sealed trait A1Notation
   object A1Notation {
+    implicit val pathPartA1Notation: PathPart[A1Notation] = _.show
     implicit val showA1Notation: Show[A1Notation] = Show.show {
       case SheetNameNotation(s) => s.toString
       case RangeNotation(r) => r.show


### PR DESCRIPTION
I was having trouble accessing spreadsheet tabs with spaces in their names. This seems to fix the problem.